### PR TITLE
feat: split auto-merge into separate workflow for reliable timing

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,70 @@
+name: Auto-merge Data PRs
+
+on:
+  pull_request:
+    branches: [master]
+    types: [labeled]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    name: Auto-merge automated-update PR
+    if: contains(github.event.pull_request.labels.*.name, 'automated-update')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Install GitHub CLI
+        run: sudo apt-get update && sudo apt-get install -y gh
+
+      - name: Wait for checks to register
+        run: |
+          echo "Waiting for PR checks to register..."
+          for i in $(seq 1 30); do
+            CHECKS=$(gh pr checks ${{ github.event.pull_request.number }} --json state --jq '.[].state' 2>/dev/null || echo "")
+            if [ -n "$CHECKS" ]; then
+              echo "Checks found: $CHECKS"
+              break
+            fi
+            echo "  No checks yet, waiting... ($i/30)"
+            sleep 1
+          done
+
+      - name: Wait for checks to pass
+        run: |
+          echo "Waiting for all checks to pass..."
+          for i in $(seq 1 60); do
+            STATE=$(gh pr checks ${{ github.event.pull_request.number }} --json conclusion --jq '.[0].conclusion' 2>/dev/null || echo "")
+            if [ "$STATE" = "SUCCESS" ]; then
+              echo "✅ All checks passed"
+              break
+            elif [ "$STATE" = "FAILURE" ] || [ "$STATE" = "ACTION_REQUIRED" ] || [ "$STATE" = "TIMED_OUT" ]; then
+              echo "❌ Checks failed — not merging"
+              gh pr comment ${{ github.event.pull_request.number }} \
+                --body "⚠️ **Auto-merge cancelled**: checks failed. Please review manually."
+              exit 1
+            fi
+            if [ "$i" -eq 60 ]; then
+              echo "⚠️ Timeout waiting for checks — attempting merge anyway"
+            fi
+            sleep 1
+          done
+
+      - name: Auto-merge with squash
+        run: |
+          echo "Merging PR #${{ github.event.pull_request.number }}..."
+          gh pr merge ${{ github.event.pull_request.number }} \
+            --squash \
+            --delete-branch \
+            --subject "chore: weekly data update from geoportal.madrid.es"
+          echo "✅ PR #${{ github.event.pull_request.number }} merged"
+
+      - name: Remove label after merge
+        if: success()
+        run: |
+          gh pr edit ${{ github.event.pull_request.number }} --remove-label automated-update

--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -16,9 +16,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: master
+          fetch-depth: 0
 
       - name: Build Docker image
         run: docker build -t zona-ser-update .
@@ -38,6 +39,10 @@ jobs:
           else
             echo "changed=true" >> $GITHUB_OUTPUT
             echo "date=$(date -u +'%Y-%m-%d %H:%M UTC')" >> $GITHUB_OUTPUT
+            # Calcular diff stats
+            echo "additions=$(git diff --numstat web/ | awk '{s+=$1} END {print s+0}')" >> $GITHUB_OUTPUT
+            echo "deletions=$(git diff --numstat web/ | awk '{s+=$2} END {print s+0}')" >> $GITHUB_OUTPUT
+            echo "files=$(git diff --name-only web/ | wc -l)" >> $GITHUB_OUTPUT
           fi
 
       - name: Create Pull Request if data changed
@@ -55,7 +60,7 @@ jobs:
             - Data source: https://geoportal.madrid.es/IDEAM_WBGEOPORTAL/dataset.iam?id=9506daa5-e317-11ec-8359-60634c31c0aa
             - Updated: ${{ steps.check_changes.outputs.date }}
             - Files: web/*.geojson
-
-            Please review and merge if changes are acceptable.
+            - Changes: +${{ steps.check_changes.outputs.additions }} / -${{ steps.check_changes.outputs.deletions }} (${{ steps.check_changes.outputs.files }} files)
           branch: data/weekly-update
           delete-branch: true
+          labels: automated-update


### PR DESCRIPTION
## What
Split the auto-merge logic from `update-data.yml` into a standalone `auto-merge.yml` workflow.

## Why
The previous approach ran auto-merge in the same workflow with `sleep 5` — not enough time for checks to register, so PRs like #14 never auto-merged.

## Changes
- **update-data.yml**: Removed the auto-merge step. Now only: fetch data → validate → create PR with `automated-update` label.
- **auto-merge.yml** (new): Triggered on `pull_request.labeled`. Detects the `automated-update` label, waits for checks to register (30s), waits for checks to pass (60s), then squash-merges.
- If checks fail: comments on the PR and aborts the merge.
- After successful merge: removes the `automated-update` label.

## Flow
```
Lunes 02:00 UTC → update-data.yml runs
  ├── Data changes? → Create PR + label automated-update
  └── No changes → Skip
       ↓
auto-merge.yml triggers (labeled)
  ├── Wait for checks register (30s max)
  ├── Wait for checks pass (60s max)
  ├── Merge squash if all green
  └── Comment + abort if any check fails
```